### PR TITLE
Wrapped RPC fetch with a try-catch block

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -41,6 +41,7 @@ export const call = async (
     return resp
   } catch (e) {
     if (fallbackApis.length === 0) throw new AiohaRpcError(-32603, 'Failed to fetch')
+    console.warn(`There was an error fetching ${method} via ${api}:`, error);
       return await call(method, params, fallbackApis[0], fallbackApis.slice(1, fallbackApis.length))
   }
 }

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -20,24 +20,29 @@ export const call = async (
   api: string = DEFAULT_API,
   fallbackApis: string[] = FALLBACK_APIS
 ): Promise<any> => {
-  const req = await fetch(api, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      method: method,
-      params: params
+  try {
+    const req = await fetch(api, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: method,
+        params: params
+      })
     })
-  })
-  if (req.status >= 400) {
+    if (req.status >= 400) {
+      if (fallbackApis.length === 0) throw new AiohaRpcError(-32603, 'Failed to fetch')
+      return await call(method, params, fallbackApis[0], fallbackApis.slice(1, fallbackApis.length))
+    }
+    const resp = await req.json()
+    return resp
+  } catch (e) {
     if (fallbackApis.length === 0) throw new AiohaRpcError(-32603, 'Failed to fetch')
-    return await call(method, params, fallbackApis[0], fallbackApis.slice(1, fallbackApis.length))
+      return await call(method, params, fallbackApis[0], fallbackApis.slice(1, fallbackApis.length))
   }
-  const resp = await req.json()
-  return resp
 }
 
 export const callRest = async <T>(


### PR DESCRIPTION
Hit error where it wouldn't try the fallback apis when blocking request to techcoderx.com via dev tools in Chrome. This fixes that error and generally makes the call block more resilient to errors.